### PR TITLE
Individual account approval resources (java)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 
 
 ## [Unreleased]
+### Added
+- IndividualAccountRequest resource
+- IndividualAccountAttachment resource
 
 ## [0.21.0] - 2026-05-28
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This SDK version is compatible with the Stark Infra API v2.
   - [Identity](#identity)
     - [IndividualIdentity](#create-individualidentities): Create individual identities
     - [IndividualDocument](#create-individualdocuments): Create individual documents
+    - [IndividualAccountRequest](#create-individualaccountrequests): Request to open an individual account
+    - [IndividualAccountAttachment](#create-individualaccountattachments): Attach supporting documents to an individual account request
   - [Webhook](#webhook):
     - [Webhook](#create-a-webhook-subscription): Configure your webhook endpoints and subscriptions
     - [WebhookEvents](#process-webhook-events): Manage Webhook events
@@ -3632,6 +3634,238 @@ You can also get a specific log by its id.
 import com.starkinfra.*;
 
 IndividualDocument.Log log = IndividualDocument.Log.get("5155165527080960");
+
+System.out.println(log);
+```
+
+### Create IndividualAccountRequests
+
+You can create IndividualAccountRequests to open a Stark Infra account for an individual. The address is a structured nested object.
+
+```java
+import com.starkinfra.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+HashMap<String, Object> address = new HashMap<>();
+address.put("street", "Rua do Estilo Barroco");
+address.put("number", "648");
+address.put("neighborhood", "Santo Amaro");
+address.put("city", "Sao Paulo");
+address.put("state", "SP");
+address.put("zipCode", "05724005");
+
+HashMap<String, Object> data = new HashMap<>();
+data.put("name", "Tony Stark");
+data.put("taxId", "012.345.678-90");
+data.put("address", address);
+data.put("income", 1000000L);
+data.put("tags", new String[]{"employees", "monthly"});
+
+List<IndividualAccountRequest> requests = new ArrayList<>();
+requests.add(new IndividualAccountRequest(data));
+
+requests = IndividualAccountRequest.create(requests);
+
+for (IndividualAccountRequest request : requests) {
+    System.out.println(request);
+}
+```
+
+**Note**: Instead of using IndividualAccountRequest objects, you can also pass each element in dictionary format
+
+### Query IndividualAccountRequests
+
+You can query multiple IndividualAccountRequests according to filters.
+
+```java
+import com.starkinfra.*;
+import com.starkinfra.utils.Generator;
+import java.util.HashMap;
+
+HashMap<String, Object> params = new HashMap<>();
+params.put("limit", 3);
+params.put("status", "created");
+params.put("after", "2019-04-01");
+params.put("before", "2030-04-30");
+
+Generator<IndividualAccountRequest> requests = IndividualAccountRequest.query(params);
+
+for (IndividualAccountRequest request : requests) {
+    System.out.println(request);
+}
+```
+
+### Get an IndividualAccountRequest
+
+After its creation, information on an IndividualAccountRequest may be retrieved by its id.
+
+```java
+import com.starkinfra.*;
+
+IndividualAccountRequest request = IndividualAccountRequest.get("5189530608992256");
+
+System.out.println(request);
+```
+
+### Update an IndividualAccountRequest
+
+You can update an IndividualAccountRequest by its id. The address is replaced as a whole object.
+
+```java
+import com.starkinfra.*;
+import java.util.HashMap;
+
+HashMap<String, Object> patchData = new HashMap<>();
+patchData.put("status", "processing");
+
+IndividualAccountRequest request = IndividualAccountRequest.update("5189530608992256", patchData);
+
+System.out.println(request);
+```
+
+### Query IndividualAccountRequest logs
+
+You can query IndividualAccountRequest logs to better understand IndividualAccountRequest life cycles.
+
+```java
+import com.starkinfra.*;
+import com.starkinfra.utils.Generator;
+import java.util.HashMap;
+
+HashMap<String, Object> params = new HashMap<>();
+params.put("limit", 3);
+params.put("after", "2019-04-01");
+params.put("before", "2030-04-30");
+
+Generator<IndividualAccountRequest.Log> logs = IndividualAccountRequest.Log.query(params);
+
+for (IndividualAccountRequest.Log log : logs) {
+    System.out.println(log);
+}
+```
+
+### Get an IndividualAccountRequest log
+
+You can also get a specific log by its id.
+
+```java
+import com.starkinfra.*;
+
+IndividualAccountRequest.Log log = IndividualAccountRequest.Log.get("5189530608992256");
+
+System.out.println(log);
+```
+
+### Create IndividualAccountAttachments
+
+You can attach supporting documents to an IndividualAccountRequest. Pass the raw image bytes and a MIME content type; the SDK encodes them as a data: URL before sending.
+
+```java
+import com.starkinfra.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+byte[] content = Files.readAllBytes(Paths.get("identity-front.png"));
+
+HashMap<String, Object> data = new HashMap<>();
+data.put("type", "identity-front");
+data.put("content", content);
+data.put("contentType", "image/png");
+data.put("accountRequestId", "5189530608992256");
+data.put("tags", new String[]{"employees"});
+
+List<IndividualAccountAttachment> attachments = new ArrayList<>();
+attachments.add(new IndividualAccountAttachment(data));
+
+attachments = IndividualAccountAttachment.create(attachments);
+
+for (IndividualAccountAttachment attachment : attachments) {
+    System.out.println(attachment);
+}
+```
+
+**Note**: Instead of using IndividualAccountAttachment objects, you can also pass each element in dictionary format
+
+### Query IndividualAccountAttachments
+
+You can query multiple IndividualAccountAttachments according to filters.
+
+```java
+import com.starkinfra.*;
+import com.starkinfra.utils.Generator;
+import java.util.HashMap;
+
+HashMap<String, Object> params = new HashMap<>();
+params.put("limit", 3);
+params.put("status", "created");
+params.put("after", "2019-04-01");
+params.put("before", "2030-04-30");
+
+Generator<IndividualAccountAttachment> attachments = IndividualAccountAttachment.query(params);
+
+for (IndividualAccountAttachment attachment : attachments) {
+    System.out.println(attachment);
+}
+```
+
+### Get an IndividualAccountAttachment
+
+After its creation, information on an IndividualAccountAttachment may be retrieved by its id.
+
+```java
+import com.starkinfra.*;
+
+IndividualAccountAttachment attachment = IndividualAccountAttachment.get("5656565656565656");
+
+System.out.println(attachment);
+```
+
+### Cancel an IndividualAccountAttachment
+
+You can cancel an IndividualAccountAttachment by its id.
+
+```java
+import com.starkinfra.*;
+
+IndividualAccountAttachment attachment = IndividualAccountAttachment.cancel("5656565656565656");
+
+System.out.println(attachment);
+```
+
+### Query IndividualAccountAttachment logs
+
+You can query IndividualAccountAttachment logs to better understand IndividualAccountAttachment life cycles.
+
+```java
+import com.starkinfra.*;
+import com.starkinfra.utils.Generator;
+import java.util.HashMap;
+
+HashMap<String, Object> params = new HashMap<>();
+params.put("limit", 3);
+params.put("after", "2019-04-01");
+params.put("before", "2030-04-30");
+
+Generator<IndividualAccountAttachment.Log> logs = IndividualAccountAttachment.Log.query(params);
+
+for (IndividualAccountAttachment.Log log : logs) {
+    System.out.println(log);
+}
+```
+
+### Get an IndividualAccountAttachment log
+
+You can also get a specific log by its id.
+
+```java
+import com.starkinfra.*;
+
+IndividualAccountAttachment.Log log = IndividualAccountAttachment.Log.get("5656565656565656");
 
 System.out.println(log);
 ```

--- a/src/main/java/com/starkinfra/IndividualAccountAttachment.java
+++ b/src/main/java/com/starkinfra/IndividualAccountAttachment.java
@@ -1,0 +1,661 @@
+package com.starkinfra;
+
+import com.starkinfra.utils.Rest;
+import com.starkinfra.utils.Resource;
+import com.starkinfra.utils.Generator;
+import com.starkcore.utils.SubResource;
+import com.starkinfra.error.ErrorElement;
+
+import java.util.Map;
+import java.util.List;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.ArrayList;
+
+
+public final class IndividualAccountAttachment extends Resource {
+    /**
+     * IndividualAccountAttachment object
+     * <p>
+     * IndividualAccountAttachments are supporting documents (identity, driver's license, selfie)
+     * attached to an IndividualAccountRequest for the account-approval flow. The caller uploads the
+     * raw image bytes and a MIME content type; the SDK encodes them as a data: URL before sending.
+     * <p>
+     * When you initialize an IndividualAccountAttachment, the entity will not be automatically
+     * created in the Stark Infra API. The 'create' function sends the objects
+     * to the Stark Infra API and returns the list of created objects.
+     * <p>
+     * Parameters:
+     * type [string]: kind of supporting document. Options: "drivers-license-front", "drivers-license-back", "identity-front", "identity-back" or "selfie"
+     * content [string]: Base64 data url of the picture, built from the raw bytes and the contentType. ex: "data:image/png;base64,/9j/4AAQSkZJRgABAQAASABIAAD..."
+     * accountRequestId [string]: ID of the parent IndividualAccountRequest. ex: "5189530608992256"
+     * tags [list of strings, default null]: list of strings for reference when searching for IndividualAccountAttachments. ex: ["employees", "monthly"]
+     * id [string]: unique id returned when the IndividualAccountAttachment is created. ex: "5656565656565656"
+     * status [string]: current IndividualAccountAttachment status. ex: "created", "success", "failed" or "deleted"
+     * created [string]: creation datetime for the IndividualAccountAttachment. ex: "2020-03-10 10:30:00.000000+00:00"
+     *
+     */
+    static ClassData data = new ClassData(IndividualAccountAttachment.class, "IndividualAccountAttachment");
+
+    public String type;
+    public String content;
+    public String accountRequestId;
+    public String[] tags;
+    public String status;
+    public String created;
+
+    /**
+     * IndividualAccountAttachment object
+     * <p>
+     * IndividualAccountAttachments are supporting documents attached to an IndividualAccountRequest.
+     * This constructor takes the content already encoded as a Base64 data: URL.
+     * <p>
+     * Parameters:
+     * @param type [string]: kind of supporting document. ex: "drivers-license-front", "drivers-license-back", "identity-front", "identity-back" or "selfie"
+     * @param content [string]: Base64 data url of the picture. ex: "data:image/png;base64,/9j/4AAQSkZJRgABAQAASABIAAD..."
+     * @param accountRequestId [string]: ID of the parent IndividualAccountRequest. ex: "5189530608992256"
+     * @param tags [list of strings, default null]: list of strings for reference when searching for IndividualAccountAttachments. ex: ["employees", "monthly"]
+     * @param id [string]: unique id returned when the IndividualAccountAttachment is created. ex: "5656565656565656"
+     * @param status [string]: current IndividualAccountAttachment status. ex: "created", "success", "failed" or "deleted"
+     * @param created [string]: creation datetime for the IndividualAccountAttachment. ex: "2020-03-10 10:30:00.000000+00:00"
+     */
+    public IndividualAccountAttachment(String type, String content, String accountRequestId,
+                                       String[] tags, String id, String status, String created) {
+        super(id);
+        this.type = type;
+        this.content = content;
+        this.accountRequestId = accountRequestId;
+        this.tags = tags;
+        this.status = status;
+        this.created = created;
+    }
+
+    /**
+     * IndividualAccountAttachment object
+     * <p>
+     * IndividualAccountAttachments are supporting documents attached to an IndividualAccountRequest.
+     * <p>
+     * When you initialize an IndividualAccountAttachment, the entity will not be automatically
+     * created in the Stark Infra API. The 'create' function sends the objects
+     * to the Stark Infra API and returns the list of created objects.
+     * <p>
+     * Parameters (required):
+     * @param data map of properties for the creation of the IndividualAccountAttachment
+     * type [string]: kind of supporting document. ex: "drivers-license-front", "drivers-license-back", "identity-front", "identity-back" or "selfie"
+     * content [byte[]]: raw image bytes. ex: Files.readAllBytes(path)
+     * contentType [string]: content MIME type. This parameter is required as input only. ex: "image/png" or "image/jpeg"
+     * accountRequestId [string]: ID of the parent IndividualAccountRequest. ex: "5189530608992256"
+     * <p>
+     * Parameters (optional):
+     * tags [list of strings, default null]: list of strings for reference when searching for IndividualAccountAttachments. ex: ["employees", "monthly"]
+     * <p>
+     * Attributes (return-only):
+     * id [string]: unique id returned when the IndividualAccountAttachment is created. ex: "5656565656565656"
+     * status [string]: current IndividualAccountAttachment status. ex: "created", "success", "failed" or "deleted"
+     * created [string]: creation datetime for the IndividualAccountAttachment. ex: "2020-03-10 10:30:00.000000+00:00"
+     * @throws Exception error in the request
+     */
+    @SuppressWarnings("unchecked")
+    public IndividualAccountAttachment(Map<String, Object> data) throws Exception {
+        super(null);
+        HashMap<String, Object> dataCopy = new HashMap<>(data);
+
+        this.type = (String) dataCopy.remove("type");
+        this.accountRequestId = (String) dataCopy.remove("accountRequestId");
+        this.tags = (String[]) dataCopy.remove("tags");
+        this.status = null;
+        this.created = null;
+
+        if (dataCopy.containsKey("contentType") && dataCopy.get("content") instanceof byte[]) {
+            byte[] content = (byte[]) dataCopy.remove("content");
+            String contentType = (String) dataCopy.remove("contentType");
+            this.content = "data:" + contentType + ";base64," + Base64.getEncoder().encodeToString(content);
+        }
+
+        if (dataCopy.containsKey("content") && dataCopy.get("content") instanceof byte[]) {
+            byte[] content = (byte[]) dataCopy.remove("content");
+            this.content = "data:;base64," + Base64.getEncoder().encodeToString(content);
+        }
+
+        if (dataCopy.containsKey("content") && dataCopy.get("content") instanceof String) {
+            this.content = (String) dataCopy.remove("content");
+        }
+
+        if (!dataCopy.isEmpty()) {
+            throw new Exception("Unknown parameters used in constructor: [" + String.join(", ", dataCopy.keySet()) + "]");
+        }
+    }
+
+    /**
+     * Retrieve a specific IndividualAccountAttachment
+     * <p>
+     * Receive a single IndividualAccountAttachment object previously created in the Stark Infra API by passing its id
+     * <p>
+     * Parameters:
+     * @param id [string]: object unique id. ex: "5656565656565656"
+     * <p>
+     * Return:
+     * @return IndividualAccountAttachment object with updated attributes
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountAttachment get(String id) throws Exception {
+        return IndividualAccountAttachment.get(id, null);
+    }
+
+    /**
+     * Retrieve a specific IndividualAccountAttachment
+     * <p>
+     * Receive a single IndividualAccountAttachment object previously created in the Stark Infra API by passing its id
+     * <p>
+     * Parameters:
+     * @param id [string]: object unique id. ex: "5656565656565656"
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return IndividualAccountAttachment object with updated attributes
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountAttachment get(String id, User user) throws Exception {
+        return Rest.getId(data, id, user);
+    }
+
+    /**
+     * Retrieve IndividualAccountAttachments
+     * <p>
+     * Receive a generator of IndividualAccountAttachment objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountAttachment objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountAttachment> query(Map<String, Object> params) throws Exception {
+        return IndividualAccountAttachment.query(params, null);
+    }
+
+    /**
+     * Retrieve IndividualAccountAttachments
+     * <p>
+     * Receive a generator of IndividualAccountAttachment objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Parameters:
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountAttachment objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountAttachment> query(User user) throws Exception {
+        return IndividualAccountAttachment.query(new HashMap<>(), user);
+    }
+
+    /**
+     * Retrieve IndividualAccountAttachments
+     * <p>
+     * Receive a generator of IndividualAccountAttachment objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountAttachment objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountAttachment> query() throws Exception {
+        return IndividualAccountAttachment.query(new HashMap<>(), null);
+    }
+
+    /**
+     * Retrieve IndividualAccountAttachments
+     * <p>
+     * Receive a generator of IndividualAccountAttachment objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountAttachment objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountAttachment> query(Map<String, Object> params, User user) throws Exception {
+        return Rest.getStream(data, params, user);
+    }
+
+    public final static class Page {
+        public List<IndividualAccountAttachment> attachments;
+        public String cursor;
+
+        public Page(List<IndividualAccountAttachment> attachments, String cursor) {
+            this.attachments = attachments;
+            this.cursor = cursor;
+        }
+    }
+
+    /**
+     * Retrieve paged IndividualAccountAttachments
+     * <p>
+     * Receive a list of up to 100 IndividualAccountAttachment objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * cursor [string, default null]: cursor returned on the previous page function call
+     * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * <p>
+     * Return:
+     * @return IndividualAccountAttachment.Page object:
+     * IndividualAccountAttachment.Page.attachments: list of IndividualAccountAttachment objects with updated attributes
+     * IndividualAccountAttachment.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment objects
+     * @throws Exception error in the request
+     */
+    public static Page page(Map<String, Object> params) throws Exception {
+        return page(params, null);
+    }
+
+    /**
+     * Retrieve paged IndividualAccountAttachments
+     * <p>
+     * Receive a list of up to 100 IndividualAccountAttachment objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Parameters:
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return IndividualAccountAttachment.Page object:
+     * IndividualAccountAttachment.Page.attachments: list of IndividualAccountAttachment objects with updated attributes
+     * IndividualAccountAttachment.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment objects
+     * @throws Exception error in the request
+     */
+    public static Page page(User user) throws Exception {
+        return page(new HashMap<>(), user);
+    }
+
+    /**
+     * Retrieve paged IndividualAccountAttachments
+     * <p>
+     * Receive a list of up to 100 IndividualAccountAttachment objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Return:
+     * @return IndividualAccountAttachment.Page object:
+     * IndividualAccountAttachment.Page.attachments: list of IndividualAccountAttachment objects with updated attributes
+     * IndividualAccountAttachment.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment objects
+     * @throws Exception error in the request
+     */
+    public static Page page() throws Exception {
+        return page(new HashMap<>(), null);
+    }
+
+    /**
+     * Retrieve paged IndividualAccountAttachments
+     * <p>
+     * Receive a list of up to 100 IndividualAccountAttachment objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * cursor [string, default null]: cursor returned on the previous page function call
+     * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return IndividualAccountAttachment.Page object:
+     * IndividualAccountAttachment.Page.attachments: list of IndividualAccountAttachment objects with updated attributes
+     * IndividualAccountAttachment.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment objects
+     * @throws Exception error in the request
+     */
+    public static Page page(Map<String, Object> params, User user) throws Exception {
+        com.starkcore.utils.Page page = Rest.getPage(data, params, user);
+        List<IndividualAccountAttachment> attachments = new ArrayList<>();
+        for (SubResource attachment: page.entities) {
+            attachments.add((IndividualAccountAttachment) attachment);
+        }
+        return new Page(attachments, page.cursor);
+    }
+
+    /**
+     * Create IndividualAccountAttachments
+     * <p>
+     * Send a list of IndividualAccountAttachment objects for creation in the Stark Infra API
+     * <p>
+     * Parameters:
+     * @param attachments [list of IndividualAccountAttachment objects or HashMaps]: list of IndividualAccountAttachment objects to be created in the API
+     * <p>
+     * Return:
+     * @return list of IndividualAccountAttachment objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static List<IndividualAccountAttachment> create(List<?> attachments) throws Exception {
+        return IndividualAccountAttachment.create(attachments, null);
+    }
+
+    /**
+     * Create IndividualAccountAttachments
+     * <p>
+     * Send a list of IndividualAccountAttachment objects for creation in the Stark Infra API
+     * <p>
+     * Parameters:
+     * @param attachments [list of IndividualAccountAttachment objects or HashMaps]: list of IndividualAccountAttachment objects to be created in the API
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return list of IndividualAccountAttachment objects with updated attributes
+     * @throws Exception error in the request
+     */
+    @SuppressWarnings("unchecked")
+    public static List<IndividualAccountAttachment> create(List<?> attachments, User user) throws Exception {
+        List<IndividualAccountAttachment> attachmentList = new ArrayList<>();
+        for (Object attachment : attachments){
+            if (attachment instanceof Map){
+                attachmentList.add(new IndividualAccountAttachment((Map<String, Object>) attachment));
+                continue;
+            }
+            if (attachment instanceof IndividualAccountAttachment){
+                attachmentList.add((IndividualAccountAttachment) attachment);
+                continue;
+            }
+            throw new Exception("Unknown type \"" + attachment.getClass() + "\", use IndividualAccountAttachment or HashMap");
+        }
+        return Rest.post(data, attachmentList, user);
+    }
+
+    /**
+     * Cancel an IndividualAccountAttachment entity
+     * <p>
+     * Cancel an IndividualAccountAttachment entity previously created in the Stark Infra API
+     * <p>
+     * Parameters:
+     * @param id [string]: IndividualAccountAttachment unique id. ex: "5656565656565656"
+     * <p>
+     * Return:
+     * @return deleted IndividualAccountAttachment object
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountAttachment cancel(String id) throws Exception {
+        return IndividualAccountAttachment.cancel(id, null);
+    }
+
+    /**
+     * Cancel an IndividualAccountAttachment entity
+     * <p>
+     * Cancel an IndividualAccountAttachment entity previously created in the Stark Infra API
+     * <p>
+     * Parameters:
+     * @param id [string]: IndividualAccountAttachment unique id. ex: "5656565656565656"
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return deleted IndividualAccountAttachment object
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountAttachment cancel(String id, User user) throws Exception {
+        return Rest.delete(data, id, user);
+    }
+
+    public final static class Log extends Resource {
+        static ClassData data = new ClassData(Log.class, "IndividualAccountAttachmentLog");
+
+        public String created;
+        public String type;
+        public List<ErrorElement> errors;
+        public IndividualAccountAttachment attachment;
+
+        /**
+         * IndividualAccountAttachment Log object
+         * <p>
+         * Every time an IndividualAccountAttachment entity is modified, a corresponding IndividualAccountAttachment Log
+         * is generated for the entity. This log is never generated by the user.
+         * <p>
+         * Attributes:
+         * @param id [string]: unique id returned when the log is created. ex: "5656565656565656"
+         * @param attachment [IndividualAccountAttachment]: IndividualAccountAttachment entity to which the log refers to.
+         * @param errors [list of ErrorElement]: list of errors linked to the IndividualAccountAttachment event.
+         * @param type [string]: type of the IndividualAccountAttachment event which triggered the log creation. ex: "success" or "failed"
+         * @param created [string]: creation datetime for the log. ex: "2020-03-10 10:30:00.000000+00:00"
+         */
+        public Log(String created, String type, List<ErrorElement> errors, IndividualAccountAttachment attachment, String id) {
+            super(id);
+            this.created = created;
+            this.type = type;
+            this.errors = errors;
+            this.attachment = attachment;
+        }
+
+        /**
+         * Retrieve a specific IndividualAccountAttachment Log
+         * <p>
+         * Receive a single IndividualAccountAttachment Log object previously created by the Stark Infra API by passing its id
+         * <p>
+         * Parameters:
+         * @param id [string]: object unique id. ex: "5656565656565656"
+         * <p>
+         * Return:
+         * @return IndividualAccountAttachment Log object with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Log get(String id) throws Exception {
+            return Log.get(id, null);
+        }
+
+        /**
+         * Retrieve a specific IndividualAccountAttachment Log
+         * <p>
+         * Receive a single IndividualAccountAttachment Log object previously created by the Stark Infra API by passing its id
+         * <p>
+         * Parameters:
+         * @param id [string]: object unique id. ex: "5656565656565656"
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return IndividualAccountAttachment Log object with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Log get(String id, User user) throws Exception {
+            return Rest.getId(data, id, user);
+        }
+
+        /**
+         * Retrieve IndividualAccountAttachment Logs
+         * <p>
+         * Receive a generator of IndividualAccountAttachment.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * attachmentIds [list of strings, default null]: list of IndividualAccountAttachment ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountAttachment Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query(Map<String, Object> params) throws Exception {
+            return Log.query(params, null);
+        }
+
+        /**
+         * Retrieve IndividualAccountAttachment Logs
+         * <p>
+         * Receive a generator of IndividualAccountAttachment.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Parameters:
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountAttachment Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query(User user) throws Exception {
+            return Log.query(new HashMap<>(), user);
+        }
+
+        /**
+         * Retrieve IndividualAccountAttachment Logs
+         * <p>
+         * Receive a generator of IndividualAccountAttachment.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountAttachment Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query() throws Exception {
+            return Log.query(new HashMap<>(), null);
+        }
+
+        /**
+         * Retrieve IndividualAccountAttachment Logs
+         * <p>
+         * Receive a generator of IndividualAccountAttachment.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * attachmentIds [list of strings, default null]: list of IndividualAccountAttachment ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountAttachment Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query(Map<String, Object> params, User user) throws Exception {
+            return Rest.getStream(data, params, user);
+        }
+
+        public final static class Page {
+            public List<Log> logs;
+            public String cursor;
+
+            public Page(List<Log> logs, String cursor) {
+                this.logs = logs;
+                this.cursor = cursor;
+            }
+        }
+
+        /**
+         * Retrieve paged IndividualAccountAttachment.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountAttachment.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * cursor [string, default null]: cursor returned on the previous page function call
+         * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * attachmentIds [list of strings, default null]: list of IndividualAccountAttachment ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * <p>
+         * Return:
+         * @return IndividualAccountAttachment.Log.Page object:
+         * IndividualAccountAttachment.Log.Page.logs: list of IndividualAccountAttachment.Log objects with updated attributes
+         * IndividualAccountAttachment.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page(Map<String, Object> params) throws Exception {
+            return Log.page(params, null);
+        }
+
+        /**
+         * Retrieve paged IndividualAccountAttachment.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountAttachment.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Parameters:
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return IndividualAccountAttachment.Log.Page object:
+         * IndividualAccountAttachment.Log.Page.logs: list of IndividualAccountAttachment.Log objects with updated attributes
+         * IndividualAccountAttachment.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page(User user) throws Exception {
+            return Log.page(new HashMap<>(), user);
+        }
+
+        /**
+         * Retrieve paged IndividualAccountAttachment.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountAttachment.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Return:
+         * @return IndividualAccountAttachment.Log.Page object:
+         * IndividualAccountAttachment.Log.Page.logs: list of IndividualAccountAttachment.Log objects with updated attributes
+         * IndividualAccountAttachment.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page() throws Exception {
+            return Log.page(new HashMap<>(), null);
+        }
+
+        /**
+         * Retrieve paged IndividualAccountAttachment.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountAttachment.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * cursor [string, default null]: cursor returned on the previous page function call
+         * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * attachmentIds [list of strings, default null]: list of IndividualAccountAttachment ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return IndividualAccountAttachment.Log.Page object:
+         * IndividualAccountAttachment.Log.Page.logs: list of IndividualAccountAttachment.Log objects with updated attributes
+         * IndividualAccountAttachment.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountAttachment.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page(Map<String, Object> params, User user) throws Exception {
+            com.starkcore.utils.Page page = Rest.getPage(data, params, user);
+            List<Log> logs = new ArrayList<>();
+            for (SubResource log: page.entities) {
+                logs.add((Log) log);
+            }
+            return new Log.Page(logs, page.cursor);
+        }
+    }
+}

--- a/src/main/java/com/starkinfra/IndividualAccountRequest.java
+++ b/src/main/java/com/starkinfra/IndividualAccountRequest.java
@@ -1,0 +1,776 @@
+package com.starkinfra;
+
+import com.starkinfra.utils.Rest;
+import com.starkinfra.utils.Resource;
+import com.starkinfra.utils.Generator;
+import com.starkcore.utils.SubResource;
+import com.starkinfra.error.ErrorElement;
+
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+
+
+public final class IndividualAccountRequest extends Resource {
+    /**
+     * IndividualAccountRequest object
+     * <p>
+     * IndividualAccountRequests are used to open a Stark Infra account for an individual. The
+     * caller submits the individual's identifying data and income, and the API runs the approval
+     * flow asynchronously, moving the request through created, processing, success, failed or canceled.
+     * <p>
+     * When you initialize an IndividualAccountRequest, the entity will not be automatically
+     * created in the Stark Infra API. The 'create' function sends the objects
+     * to the Stark Infra API and returns the list of created objects.
+     * <p>
+     * Parameters:
+     * name [string]: full legal name of the individual. ex: "Tony Stark"
+     * taxId [string]: Brazilian CPF with or without formatting. ex: "012.345.678-90" or "01234567890"
+     * address [IndividualAccountRequest.Address]: structured residential address. ex: new IndividualAccountRequest.Address(data)
+     * income [Long]: monthly income in cents. Must be greater than 0. ex: 1000000 (= R$ 10,000.00)
+     * tags [list of strings, default null]: list of strings for reference when searching for IndividualAccountRequests. ex: ["employees", "monthly"]
+     * id [string]: unique id returned when the IndividualAccountRequest is created. ex: "5189530608992256"
+     * status [string]: current IndividualAccountRequest status. ex: "created", "processing", "success", "failed" or "canceled"
+     * accountType [string]: account-request kind. Always "individual" for this resource. ex: "individual"
+     * flags [list of strings]: server-side review flags. Empty unless the request triggered a manual-review condition. ex: ["manualReview"]
+     * created [string]: creation datetime for the IndividualAccountRequest. ex: "2020-03-10 10:30:00.000000+00:00"
+     * updated [string]: latest update datetime for the IndividualAccountRequest. ex: "2020-03-10 10:30:00.000000+00:00"
+     *
+     */
+    static ClassData data = new ClassData(IndividualAccountRequest.class, "IndividualAccountRequest");
+
+    public String name;
+    public String taxId;
+    public Address address;
+    public Long income;
+    public String[] tags;
+    public String accountType;
+    public String[] flags;
+    public String status;
+    public String created;
+    public String updated;
+
+    /**
+     * IndividualAccountRequest object
+     * <p>
+     * IndividualAccountRequests are used to open a Stark Infra account for an individual.
+     * <p>
+     * When you initialize an IndividualAccountRequest, the entity will not be automatically
+     * created in the Stark Infra API. The 'create' function sends the objects
+     * to the Stark Infra API and returns the list of created objects.
+     * <p>
+     * Parameters:
+     * @param name [string]: full legal name of the individual. ex: "Tony Stark"
+     * @param taxId [string]: Brazilian CPF with or without formatting. ex: "012.345.678-90" or "01234567890"
+     * @param address [IndividualAccountRequest.Address]: structured residential address.
+     * @param income [Long]: monthly income in cents. Must be greater than 0. ex: 1000000 (= R$ 10,000.00)
+     * @param tags [list of strings, default null]: list of strings for reference when searching for IndividualAccountRequests. ex: ["employees", "monthly"]
+     * @param id [string]: unique id returned when the IndividualAccountRequest is created. ex: "5189530608992256"
+     * @param status [string]: current IndividualAccountRequest status. ex: "created", "processing", "success", "failed" or "canceled"
+     * @param accountType [string]: account-request kind. Always "individual" for this resource. ex: "individual"
+     * @param flags [list of strings]: server-side review flags. ex: ["manualReview"]
+     * @param created [string]: creation datetime for the IndividualAccountRequest. ex: "2020-03-10 10:30:00.000000+00:00"
+     * @param updated [string]: latest update datetime for the IndividualAccountRequest. ex: "2020-03-10 10:30:00.000000+00:00"
+     */
+    public IndividualAccountRequest(String name, String taxId, Address address, Long income, String[] tags,
+                                    String id, String status, String accountType, String[] flags,
+                                    String created, String updated) {
+        super(id);
+        this.name = name;
+        this.taxId = taxId;
+        this.address = address;
+        this.income = income;
+        this.tags = tags;
+        this.status = status;
+        this.accountType = accountType;
+        this.flags = flags;
+        this.created = created;
+        this.updated = updated;
+    }
+
+    /**
+     * IndividualAccountRequest object
+     * <p>
+     * IndividualAccountRequests are used to open a Stark Infra account for an individual.
+     * <p>
+     * When you initialize an IndividualAccountRequest, the entity will not be automatically
+     * created in the Stark Infra API. The 'create' function sends the objects
+     * to the Stark Infra API and returns the list of created objects.
+     * <p>
+     * Parameters (required):
+     * @param data map of properties for the creation of the IndividualAccountRequest
+     * name [string]: full legal name of the individual. ex: "Tony Stark"
+     * taxId [string]: Brazilian CPF with or without formatting. ex: "012.345.678-90" or "01234567890"
+     * address [IndividualAccountRequest.Address or map]: structured residential address.
+     * income [Long]: monthly income in cents. Must be greater than 0. ex: 1000000 (= R$ 10,000.00)
+     * <p>
+     * Parameters (optional):
+     * tags [list of strings, default null]: list of strings for reference when searching for IndividualAccountRequests. ex: ["employees", "monthly"]
+     * <p>
+     * Attributes (return-only):
+     * id [string]: unique id returned when the IndividualAccountRequest is created. ex: "5189530608992256"
+     * status [string]: current IndividualAccountRequest status. ex: "created", "processing", "success", "failed" or "canceled"
+     * accountType [string]: account-request kind. Always "individual" for this resource. ex: "individual"
+     * flags [list of strings]: server-side review flags. ex: ["manualReview"]
+     * created [string]: creation datetime for the IndividualAccountRequest. ex: "2020-03-10 10:30:00.000000+00:00"
+     * updated [string]: latest update datetime for the IndividualAccountRequest. ex: "2020-03-10 10:30:00.000000+00:00"
+     * @throws Exception error in the request
+     */
+    @SuppressWarnings("unchecked")
+    public IndividualAccountRequest(Map<String, Object> data) throws Exception {
+        super(null);
+        HashMap<String, Object> dataCopy = new HashMap<>(data);
+
+        this.name = (String) dataCopy.remove("name");
+        this.taxId = (String) dataCopy.remove("taxId");
+        this.address = parseAddress(dataCopy.remove("address"));
+        this.income = ((Number) dataCopy.remove("income")).longValue();
+        this.tags = (String[]) dataCopy.remove("tags");
+        this.status = null;
+        this.accountType = null;
+        this.flags = null;
+        this.created = null;
+        this.updated = null;
+
+        if (!dataCopy.isEmpty()) {
+            throw new Exception("Unknown parameters used in constructor: [" + String.join(", ", dataCopy.keySet()) + "]");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Address parseAddress(Object address) throws Exception {
+        if (address == null)
+            return null;
+
+        if (address instanceof Address) {
+            return (Address) address;
+        }
+
+        return new Address((Map<String, Object>) address);
+    }
+
+    /**
+     * Retrieve a specific IndividualAccountRequest
+     * <p>
+     * Receive a single IndividualAccountRequest object previously created in the Stark Infra API by passing its id
+     * <p>
+     * Parameters:
+     * @param id [string]: object unique id. ex: "5189530608992256"
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest object with updated attributes
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountRequest get(String id) throws Exception {
+        return IndividualAccountRequest.get(id, null);
+    }
+
+    /**
+     * Retrieve a specific IndividualAccountRequest
+     * <p>
+     * Receive a single IndividualAccountRequest object previously created in the Stark Infra API by passing its id
+     * <p>
+     * Parameters:
+     * @param id [string]: object unique id. ex: "5189530608992256"
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest object with updated attributes
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountRequest get(String id, User user) throws Exception {
+        return Rest.getId(data, id, user);
+    }
+
+    /**
+     * Retrieve IndividualAccountRequests
+     * <p>
+     * Receive a generator of IndividualAccountRequest objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountRequest objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountRequest> query(Map<String, Object> params) throws Exception {
+        return IndividualAccountRequest.query(params, null);
+    }
+
+    /**
+     * Retrieve IndividualAccountRequests
+     * <p>
+     * Receive a generator of IndividualAccountRequest objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Parameters:
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountRequest objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountRequest> query(User user) throws Exception {
+        return IndividualAccountRequest.query(new HashMap<>(), user);
+    }
+
+    /**
+     * Retrieve IndividualAccountRequests
+     * <p>
+     * Receive a generator of IndividualAccountRequest objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountRequest objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountRequest> query() throws Exception {
+        return IndividualAccountRequest.query(new HashMap<>(), null);
+    }
+
+    /**
+     * Retrieve IndividualAccountRequests
+     * <p>
+     * Receive a generator of IndividualAccountRequest objects previously created in the Stark Infra API.
+     * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return generator of IndividualAccountRequest objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static Generator<IndividualAccountRequest> query(Map<String, Object> params, User user) throws Exception {
+        return Rest.getStream(data, params, user);
+    }
+
+    public final static class Page {
+        public List<IndividualAccountRequest> requests;
+        public String cursor;
+
+        public Page(List<IndividualAccountRequest> requests, String cursor) {
+            this.requests = requests;
+            this.cursor = cursor;
+        }
+    }
+
+    /**
+     * Retrieve paged IndividualAccountRequests
+     * <p>
+     * Receive a list of up to 100 IndividualAccountRequest objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * cursor [string, default null]: cursor returned on the previous page function call
+     * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest.Page object:
+     * IndividualAccountRequest.Page.requests: list of IndividualAccountRequest objects with updated attributes
+     * IndividualAccountRequest.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest objects
+     * @throws Exception error in the request
+     */
+    public static Page page(Map<String, Object> params) throws Exception {
+        return page(params, null);
+    }
+
+    /**
+     * Retrieve paged IndividualAccountRequests
+     * <p>
+     * Receive a list of up to 100 IndividualAccountRequest objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Parameters:
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest.Page object:
+     * IndividualAccountRequest.Page.requests: list of IndividualAccountRequest objects with updated attributes
+     * IndividualAccountRequest.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest objects
+     * @throws Exception error in the request
+     */
+    public static Page page(User user) throws Exception {
+        return page(new HashMap<>(), user);
+    }
+
+    /**
+     * Retrieve paged IndividualAccountRequests
+     * <p>
+     * Receive a list of up to 100 IndividualAccountRequest objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest.Page object:
+     * IndividualAccountRequest.Page.requests: list of IndividualAccountRequest objects with updated attributes
+     * IndividualAccountRequest.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest objects
+     * @throws Exception error in the request
+     */
+    public static Page page() throws Exception {
+        return page(new HashMap<>(), null);
+    }
+
+    /**
+     * Retrieve paged IndividualAccountRequests
+     * <p>
+     * Receive a list of up to 100 IndividualAccountRequest objects previously created in the Stark Infra API and the cursor to the next page.
+     * Use this function instead of query if you want to manually page your requests.
+     * <p>
+     * Parameters:
+     * @param params map of parameters for the query
+     * cursor [string, default null]: cursor returned on the previous page function call
+     * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+     * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-10"
+     * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+     * status [string, default null]: filter for status of retrieved objects. ex: "created"
+     * tags [list of strings, default null]: tags to filter retrieved objects. ex: ["tony", "stark"]
+     * ids [list of strings, default null]: list of ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest.Page object:
+     * IndividualAccountRequest.Page.requests: list of IndividualAccountRequest objects with updated attributes
+     * IndividualAccountRequest.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest objects
+     * @throws Exception error in the request
+     */
+    public static Page page(Map<String, Object> params, User user) throws Exception {
+        com.starkcore.utils.Page page = Rest.getPage(data, params, user);
+        List<IndividualAccountRequest> requests = new ArrayList<>();
+        for (SubResource request: page.entities) {
+            requests.add((IndividualAccountRequest) request);
+        }
+        return new Page(requests, page.cursor);
+    }
+
+    /**
+     * Create IndividualAccountRequests
+     * <p>
+     * Send a list of IndividualAccountRequest objects for creation in the Stark Infra API
+     * <p>
+     * Parameters:
+     * @param requests [list of IndividualAccountRequest objects or HashMaps]: list of IndividualAccountRequest objects to be created in the API
+     * <p>
+     * Return:
+     * @return list of IndividualAccountRequest objects with updated attributes
+     * @throws Exception error in the request
+     */
+    public static List<IndividualAccountRequest> create(List<?> requests) throws Exception {
+        return IndividualAccountRequest.create(requests, null);
+    }
+
+    /**
+     * Create IndividualAccountRequests
+     * <p>
+     * Send a list of IndividualAccountRequest objects for creation in the Stark Infra API
+     * <p>
+     * Parameters:
+     * @param requests [list of IndividualAccountRequest objects or HashMaps]: list of IndividualAccountRequest objects to be created in the API
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return list of IndividualAccountRequest objects with updated attributes
+     * @throws Exception error in the request
+     */
+    @SuppressWarnings("unchecked")
+    public static List<IndividualAccountRequest> create(List<?> requests, User user) throws Exception {
+        List<IndividualAccountRequest> requestList = new ArrayList<>();
+        for (Object request : requests){
+            if (request instanceof Map){
+                requestList.add(new IndividualAccountRequest((Map<String, Object>) request));
+                continue;
+            }
+            if (request instanceof IndividualAccountRequest){
+                requestList.add((IndividualAccountRequest) request);
+                continue;
+            }
+            throw new Exception("Unknown type \"" + request.getClass() + "\", use IndividualAccountRequest or HashMap");
+        }
+        return Rest.post(data, requestList, user);
+    }
+
+    /**
+     * Update IndividualAccountRequest entity
+     * <p>
+     * Update an IndividualAccountRequest by passing id.
+     * <p>
+     * Parameters:
+     * @param id [string]: IndividualAccountRequest id. ex: "5189530608992256"
+     * @param patchData map of parameters
+     * name [string, default null]: replace the legal name. ex: "Tony Stark"
+     * taxId [string, default null]: replace the CPF. ex: "012.345.678-90"
+     * address [map, default null]: replace the address as a whole object (no partial address PATCH).
+     * income [Long, default null]: replace monthly income in cents. ex: 1000000
+     * status [string, default null]: manual state transition. ex: "processing"
+     * tags [list of strings, default null]: replace tag list. ex: ["employees", "monthly"]
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest object with updated attributes
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountRequest update(String id, Map<String, Object> patchData) throws Exception {
+        return IndividualAccountRequest.update(id, patchData, null);
+    }
+
+    /**
+     * Update IndividualAccountRequest entity
+     * <p>
+     * Update an IndividualAccountRequest by passing id.
+     * <p>
+     * Parameters:
+     * @param id [string]: IndividualAccountRequest id. ex: "5189530608992256"
+     * @param patchData map of parameters
+     * name [string, default null]: replace the legal name. ex: "Tony Stark"
+     * taxId [string, default null]: replace the CPF. ex: "012.345.678-90"
+     * address [map, default null]: replace the address as a whole object (no partial address PATCH).
+     * income [Long, default null]: replace monthly income in cents. ex: 1000000
+     * status [string, default null]: manual state transition. ex: "processing"
+     * tags [list of strings, default null]: replace tag list. ex: ["employees", "monthly"]
+     * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+     * <p>
+     * Return:
+     * @return IndividualAccountRequest object with updated attributes
+     * @throws Exception error in the request
+     */
+    public static IndividualAccountRequest update(String id, Map<String, Object> patchData, User user) throws Exception {
+        return Rest.patch(data, id, patchData, user);
+    }
+
+    /**
+     * IndividualAccountRequest.Address object
+     * <p>
+     * Embedded value object describing the individual's residential address. It has no endpoints
+     * of its own; it is exposed only as the address field on the parent and is serialized as a
+     * nested JSON object on the wire.
+     * <p>
+     * Parameters:
+     * street [string]: street name. ex: "Rua do Estilo Barroco"
+     * number [string]: street number. ex: "648"
+     * neighborhood [string]: neighborhood / district. ex: "Santo Amaro"
+     * city [string]: city. ex: "Sao Paulo"
+     * state [string]: state (BR 2-letter code). ex: "SP"
+     * zipCode [string]: ZIP code (BR CEP) with or without formatting. ex: "05724005"
+     *
+     */
+    public final static class Address extends SubResource {
+        public String street;
+        public String number;
+        public String neighborhood;
+        public String city;
+        public String state;
+        public String zipCode;
+
+        /**
+         * IndividualAccountRequest.Address object
+         * <p>
+         * Embedded value object describing the individual's residential address.
+         * <p>
+         * Parameters:
+         * @param street [string]: street name. ex: "Rua do Estilo Barroco"
+         * @param number [string]: street number. ex: "648"
+         * @param neighborhood [string]: neighborhood / district. ex: "Santo Amaro"
+         * @param city [string]: city. ex: "Sao Paulo"
+         * @param state [string]: state (BR 2-letter code). ex: "SP"
+         * @param zipCode [string]: ZIP code (BR CEP) with or without formatting. ex: "05724005"
+         */
+        public Address(String street, String number, String neighborhood, String city, String state, String zipCode) {
+            this.street = street;
+            this.number = number;
+            this.neighborhood = neighborhood;
+            this.city = city;
+            this.state = state;
+            this.zipCode = zipCode;
+        }
+
+        /**
+         * IndividualAccountRequest.Address object
+         * <p>
+         * Embedded value object describing the individual's residential address.
+         * <p>
+         * Parameters:
+         * @param data map of properties for the creation of the IndividualAccountRequest.Address
+         * street [string]: street name. ex: "Rua do Estilo Barroco"
+         * number [string]: street number. ex: "648"
+         * neighborhood [string]: neighborhood / district. ex: "Santo Amaro"
+         * city [string]: city. ex: "Sao Paulo"
+         * state [string]: state (BR 2-letter code). ex: "SP"
+         * zipCode [string]: ZIP code (BR CEP) with or without formatting. ex: "05724005"
+         * @throws Exception error in the request
+         */
+        public Address(Map<String, Object> data) throws Exception {
+            HashMap<String, Object> dataCopy = new HashMap<>(data);
+
+            this.street = (String) dataCopy.remove("street");
+            this.number = (String) dataCopy.remove("number");
+            this.neighborhood = (String) dataCopy.remove("neighborhood");
+            this.city = (String) dataCopy.remove("city");
+            this.state = (String) dataCopy.remove("state");
+            this.zipCode = (String) dataCopy.remove("zipCode");
+
+            if (!dataCopy.isEmpty()) {
+                throw new Exception("Unknown parameters used in constructor: [" + String.join(", ", dataCopy.keySet()) + "]");
+            }
+        }
+    }
+
+    public final static class Log extends Resource {
+        static ClassData data = new ClassData(Log.class, "IndividualAccountRequestLog");
+
+        public String created;
+        public String type;
+        public List<ErrorElement> errors;
+        public IndividualAccountRequest request;
+
+        /**
+         * IndividualAccountRequest Log object
+         * <p>
+         * Every time an IndividualAccountRequest entity is modified, a corresponding IndividualAccountRequest Log
+         * is generated for the entity. This log is never generated by the user.
+         * <p>
+         * Attributes:
+         * @param id [string]: unique id returned when the log is created. ex: "5656565656565656"
+         * @param request [IndividualAccountRequest]: IndividualAccountRequest entity to which the log refers to.
+         * @param errors [list of ErrorElement]: list of errors linked to the IndividualAccountRequest event.
+         * @param type [string]: type of the IndividualAccountRequest event which triggered the log creation. ex: "processing" or "success"
+         * @param created [string]: creation datetime for the log. ex: "2020-03-10 10:30:00.000000+00:00"
+         */
+        public Log(String created, String type, List<ErrorElement> errors, IndividualAccountRequest request, String id) {
+            super(id);
+            this.created = created;
+            this.type = type;
+            this.errors = errors;
+            this.request = request;
+        }
+
+        /**
+         * Retrieve a specific IndividualAccountRequest Log
+         * <p>
+         * Receive a single IndividualAccountRequest Log object previously created by the Stark Infra API by passing its id
+         * <p>
+         * Parameters:
+         * @param id [string]: object unique id. ex: "5656565656565656"
+         * <p>
+         * Return:
+         * @return IndividualAccountRequest Log object with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Log get(String id) throws Exception {
+            return Log.get(id, null);
+        }
+
+        /**
+         * Retrieve a specific IndividualAccountRequest Log
+         * <p>
+         * Receive a single IndividualAccountRequest Log object previously created by the Stark Infra API by passing its id
+         * <p>
+         * Parameters:
+         * @param id [string]: object unique id. ex: "5656565656565656"
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return IndividualAccountRequest Log object with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Log get(String id, User user) throws Exception {
+            return Rest.getId(data, id, user);
+        }
+
+        /**
+         * Retrieve IndividualAccountRequest Logs
+         * <p>
+         * Receive a generator of IndividualAccountRequest.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * accountRequestIds [list of strings, default null]: list of IndividualAccountRequest ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountRequest Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query(Map<String, Object> params) throws Exception {
+            return Log.query(params, null);
+        }
+
+        /**
+         * Retrieve IndividualAccountRequest Logs
+         * <p>
+         * Receive a generator of IndividualAccountRequest.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Parameters:
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountRequest Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query(User user) throws Exception {
+            return Log.query(new HashMap<>(), user);
+        }
+
+        /**
+         * Retrieve IndividualAccountRequest Logs
+         * <p>
+         * Receive a generator of IndividualAccountRequest.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountRequest Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query() throws Exception {
+            return Log.query(new HashMap<>(), null);
+        }
+
+        /**
+         * Retrieve IndividualAccountRequest Logs
+         * <p>
+         * Receive a generator of IndividualAccountRequest.Log objects previously created in the Stark Infra API.
+         * Use this function instead of page if you want to stream the objects without worrying about cursors and pagination.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * limit [integer, default null]: maximum number of objects to be retrieved. Unlimited if null. ex: 35
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * accountRequestIds [list of strings, default null]: list of IndividualAccountRequest ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return generator of IndividualAccountRequest Log objects with updated attributes
+         * @throws Exception error in the request
+         */
+        public static Generator<Log> query(Map<String, Object> params, User user) throws Exception {
+            return Rest.getStream(data, params, user);
+        }
+
+        public final static class Page {
+            public List<Log> logs;
+            public String cursor;
+
+            public Page(List<Log> logs, String cursor) {
+                this.logs = logs;
+                this.cursor = cursor;
+            }
+        }
+
+        /**
+         * Retrieve paged IndividualAccountRequest.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountRequest.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * cursor [string, default null]: cursor returned on the previous page function call
+         * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * accountRequestIds [list of strings, default null]: list of IndividualAccountRequest ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * <p>
+         * Return:
+         * @return IndividualAccountRequest.Log.Page object:
+         * IndividualAccountRequest.Log.Page.logs: list of IndividualAccountRequest.Log objects with updated attributes
+         * IndividualAccountRequest.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page(Map<String, Object> params) throws Exception {
+            return Log.page(params, null);
+        }
+
+        /**
+         * Retrieve paged IndividualAccountRequest.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountRequest.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Parameters:
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return IndividualAccountRequest.Log.Page object:
+         * IndividualAccountRequest.Log.Page.logs: list of IndividualAccountRequest.Log objects with updated attributes
+         * IndividualAccountRequest.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page(User user) throws Exception {
+            return Log.page(new HashMap<>(), user);
+        }
+
+        /**
+         * Retrieve paged IndividualAccountRequest.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountRequest.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Return:
+         * @return IndividualAccountRequest.Log.Page object:
+         * IndividualAccountRequest.Log.Page.logs: list of IndividualAccountRequest.Log objects with updated attributes
+         * IndividualAccountRequest.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page() throws Exception {
+            return Log.page(new HashMap<>(), null);
+        }
+
+        /**
+         * Retrieve paged IndividualAccountRequest.Logs
+         * <p>
+         * Receive a list of up to 100 IndividualAccountRequest.Log objects previously created in the Stark Infra API and the cursor to the next page.
+         * Use this function instead of query if you want to manually page your requests.
+         * <p>
+         * Parameters:
+         * @param params map of parameters for the query
+         * cursor [string, default null]: cursor returned on the previous page function call
+         * limit [integer, default 100]: maximum number of objects to be retrieved. It must be an integer between 1 and 100. ex: 50
+         * after [string, default null]: date filter for objects created only after specified date. ex: "2020-03-09"
+         * before [string, default null]: date filter for objects created only before specified date. ex: "2020-03-10"
+         * types [list of strings, default null]: filter retrieved objects by types. ex: "success" or "failed"
+         * accountRequestIds [list of strings, default null]: list of IndividualAccountRequest ids to filter retrieved objects. ex: ["5656565656565656", "4545454545454545"]
+         * @param user [Organization/Project object, default null]: Organization or Project object. Not necessary if starkinfra.Settings.user was set before function call
+         * <p>
+         * Return:
+         * @return IndividualAccountRequest.Log.Page object:
+         * IndividualAccountRequest.Log.Page.logs: list of IndividualAccountRequest.Log objects with updated attributes
+         * IndividualAccountRequest.Log.Page.cursor: cursor to retrieve the next page of IndividualAccountRequest.Log objects
+         * @throws Exception error in the request
+         */
+        public static Log.Page page(Map<String, Object> params, User user) throws Exception {
+            com.starkcore.utils.Page page = Rest.getPage(data, params, user);
+            List<Log> logs = new ArrayList<>();
+            for (SubResource log: page.entities) {
+                logs.add((Log) log);
+            }
+            return new Log.Page(logs, page.cursor);
+        }
+    }
+}

--- a/src/test/java/TestIndividualAccountAttachment.java
+++ b/src/test/java/TestIndividualAccountAttachment.java
@@ -1,0 +1,412 @@
+import org.junit.Test;
+
+import com.starkinfra.Settings;
+import com.starkinfra.IndividualAccountAttachment;
+import com.starkinfra.IndividualAccountRequest;
+import com.starkinfra.utils.Generator;
+import com.starkcore.error.InputErrors;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+public class TestIndividualAccountAttachment {
+
+    @Test
+    public void testCreate() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        List<IndividualAccountAttachment> attachments = new ArrayList<>();
+        attachments.add(example());
+
+        attachments = IndividualAccountAttachment.create(attachments);
+
+        for (IndividualAccountAttachment attachment : attachments) {
+            assertNotNull(attachment.id);
+            assertNotNull(attachment.status);
+            assertNotNull(attachment.created);
+            String id = IndividualAccountAttachment.get(attachment.id).id;
+            assertEquals(id, attachment.id);
+        }
+    }
+
+    @Test
+    public void testConstructorEncodesDataUrl() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        IndividualAccountAttachment attachment = example();
+
+        assertNotNull(attachment.content);
+        assertTrue(
+            "content must be encoded as a data:<contentType>;base64,... URL",
+            attachment.content.startsWith("data:image/png;base64,")
+        );
+    }
+
+    @Test
+    public void testContentTypeIsInputOnly() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> responseData = new HashMap<>();
+        responseData.put("id", "5189530608992256");
+        responseData.put("type", "identity-front");
+        responseData.put("content", "data:image/png;base64,aGVsbG8=");
+        responseData.put("accountRequestId", "5189530608992256");
+        responseData.put("status", "created");
+        responseData.put("contentType", "image/png");
+
+        try {
+            new IndividualAccountAttachment(responseData);
+            throw new Exception("expected the constructor to reject the input-only contentType field");
+        } catch (Exception e) {
+            assertTrue(
+                "expected unknown-parameter rejection mentioning contentType, got: " + e.getMessage(),
+                e.getMessage() != null && e.getMessage().contains("contentType")
+            );
+        }
+    }
+
+    @Test
+    public void testQueryGet() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 3);
+        params.put("status", "created");
+        params.put("after", "2019-04-01");
+        params.put("before", "2030-04-30");
+        Generator<IndividualAccountAttachment> attachments = IndividualAccountAttachment.query(params);
+
+        int i = 0;
+        for (IndividualAccountAttachment attachment : attachments) {
+            i += 1;
+            attachment = IndividualAccountAttachment.get(attachment.id);
+            assertNotNull(attachment.id);
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testQueryIds() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 10);
+        params.put("tags", new String[]{"employees"});
+        Generator<IndividualAccountAttachment> attachments = IndividualAccountAttachment.query(params);
+
+        int i = 0;
+        ArrayList<String> idsExpected = new ArrayList<>();
+        for (IndividualAccountAttachment attachment : attachments) {
+            i += 1;
+            assertNotNull(attachment.id);
+            idsExpected.add(attachment.id);
+        }
+
+        params.put("ids", idsExpected.toArray(new String[0]));
+        Generator<IndividualAccountAttachment> result = IndividualAccountAttachment.query(params);
+
+        int n = 0;
+        ArrayList<String> idsResult = new ArrayList<>();
+        for (IndividualAccountAttachment attachment : result) {
+            n += 1;
+            assertNotNull(attachment.id);
+            idsResult.add(attachment.id);
+        }
+
+        Collections.sort(idsExpected);
+        Collections.sort(idsResult);
+        assertTrue(i > 0);
+        assertTrue(n > 0);
+        assertEquals(idsExpected, idsResult);
+    }
+
+    @Test
+    public void testPage() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 2);
+        params.put("after", "2019-04-01");
+        params.put("before", "2030-04-30");
+        params.put("cursor", null);
+
+        List<String> ids = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            IndividualAccountAttachment.Page page = IndividualAccountAttachment.page(params);
+            for (IndividualAccountAttachment attachment : page.attachments) {
+                if (ids.contains(attachment.id)) {
+                    throw new Exception("repeated id");
+                }
+                ids.add(attachment.id);
+            }
+            if (page.cursor == null) {
+                break;
+            }
+            params.put("cursor", page.cursor);
+        }
+
+        if (ids.size() != 4) {
+            throw new Exception("ids.size() != 4");
+        }
+    }
+
+    @Test
+    public void testCancel() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        IndividualAccountAttachment created =
+            IndividualAccountAttachment.create(Collections.singletonList(example())).get(0);
+
+        IndividualAccountAttachment canceled = IndividualAccountAttachment.cancel(created.id);
+        assertEquals("deleted", canceled.status);
+    }
+
+    @Test
+    public void testLogQueryAndGet() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 3);
+        params.put("after", "2019-04-01");
+        params.put("before", "2030-04-30");
+        params.put("types", new String[]{"created"});
+        Generator<IndividualAccountAttachment.Log> logs = IndividualAccountAttachment.Log.query(params);
+
+        int i = 0;
+        for (IndividualAccountAttachment.Log log : logs) {
+            i += 1;
+            log = IndividualAccountAttachment.Log.get(log.id);
+            assertNotNull(log.id);
+            assertNotNull(log.attachment.id);
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testLogQueryAttachmentIds() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 5);
+        Generator<IndividualAccountAttachment.Log> logs = IndividualAccountAttachment.Log.query(params);
+
+        ArrayList<String> attachmentIds = new ArrayList<>();
+        for (IndividualAccountAttachment.Log log : logs) {
+            attachmentIds.add(log.attachment.id);
+        }
+
+        HashMap<String, Object> filterParams = new HashMap<>();
+        filterParams.put("limit", 5);
+        filterParams.put("attachmentIds", attachmentIds.toArray(new String[0]));
+        Generator<IndividualAccountAttachment.Log> filtered = IndividualAccountAttachment.Log.query(filterParams);
+
+        int i = 0;
+        for (IndividualAccountAttachment.Log log : filtered) {
+            i += 1;
+            assertNotNull(log.id);
+            assertTrue(attachmentIds.contains(log.attachment.id));
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testLogPage() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 2);
+        params.put("after", "2019-04-01");
+        params.put("before", "2030-04-30");
+        params.put("cursor", null);
+
+        List<String> ids = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            IndividualAccountAttachment.Log.Page page = IndividualAccountAttachment.Log.page(params);
+            for (IndividualAccountAttachment.Log log : page.logs) {
+                if (ids.contains(log.id)) {
+                    throw new Exception("repeated id");
+                }
+                ids.add(log.id);
+            }
+            if (page.cursor == null) {
+                break;
+            }
+            params.put("cursor", page.cursor);
+        }
+
+        if (ids.size() != 4) {
+            throw new Exception("ids.size() != 4");
+        }
+    }
+
+    @Test
+    public void testTypeEnum() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        List<String> allowed = Arrays.asList(
+            "drivers-license-front", "drivers-license-back",
+            "identity-front", "identity-back"
+        );
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 5);
+        Generator<IndividualAccountAttachment> attachments = IndividualAccountAttachment.query(params);
+
+        int i = 0;
+        for (IndividualAccountAttachment attachment : attachments) {
+            i += 1;
+            assertTrue("unexpected type: " + attachment.type, allowed.contains(attachment.type));
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testDateTimeParsing() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 1);
+        Generator<IndividualAccountAttachment> attachments = IndividualAccountAttachment.query(params);
+
+        int i = 0;
+        for (IndividualAccountAttachment attachment : attachments) {
+            i += 1;
+            assertNotNull(attachment.created);
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testCreateInvalidType() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.put("type", "not-a-real-type");
+
+        List<IndividualAccountAttachment> attachments = new ArrayList<>();
+        attachments.add(new IndividualAccountAttachment(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountAttachment.create(attachments);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testCreateInvalidContent() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.put("content", new byte[]{});
+
+        List<IndividualAccountAttachment> attachments = new ArrayList<>();
+        attachments.add(new IndividualAccountAttachment(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountAttachment.create(attachments);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testCreateInvalidContentType() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.remove("contentType");
+
+        List<IndividualAccountAttachment> attachments = new ArrayList<>();
+        attachments.add(new IndividualAccountAttachment(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountAttachment.create(attachments);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testCreateAccountRequestNotFound() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.put("accountRequestId", "0");
+
+        List<IndividualAccountAttachment> attachments = new ArrayList<>();
+        attachments.add(new IndividualAccountAttachment(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountAttachment.create(attachments);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testCancelIdempotent() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        IndividualAccountAttachment attachment = example();
+        List<IndividualAccountAttachment> created =
+            IndividualAccountAttachment.create(Collections.singletonList(attachment));
+        String id = created.get(0).id;
+
+        IndividualAccountAttachment firstCancel = IndividualAccountAttachment.cancel(id);
+        assertEquals("deleted", firstCancel.status);
+
+        IndividualAccountAttachment secondCancel = IndividualAccountAttachment.cancel(id);
+        assertEquals("deleted", secondCancel.status);
+    }
+
+    @Test
+    public void testGetNotFound() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        boolean raised = false;
+        try {
+            IndividualAccountAttachment.get("0");
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    static IndividualAccountAttachment example() throws Exception {
+        return new IndividualAccountAttachment(exampleData());
+    }
+
+    static HashMap<String, Object> exampleData() throws Exception {
+        IndividualAccountRequest parent = TestIndividualAccountRequest.example();
+        List<IndividualAccountRequest> created =
+            IndividualAccountRequest.create(Collections.singletonList(parent));
+        String accountRequestId = created.get(0).id;
+
+        byte[] content = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("type", "identity-front");
+        data.put("content", content);
+        data.put("contentType", "image/png");
+        data.put("accountRequestId", accountRequestId);
+        data.put("tags", new String[]{"employees"});
+        return data;
+    }
+}

--- a/src/test/java/TestIndividualAccountRequest.java
+++ b/src/test/java/TestIndividualAccountRequest.java
@@ -1,0 +1,450 @@
+import org.junit.Test;
+
+import com.starkinfra.Settings;
+import com.starkinfra.IndividualAccountRequest;
+import com.starkinfra.utils.Generator;
+import com.starkcore.error.InputErrors;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+public class TestIndividualAccountRequest {
+
+    @Test
+    public void testCreate() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        List<IndividualAccountRequest> requests = new ArrayList<>();
+        requests.add(example());
+
+        requests = IndividualAccountRequest.create(requests);
+
+        for (IndividualAccountRequest request : requests) {
+            assertNotNull(request.id);
+            assertNotNull(request.status);
+            assertEquals("individual", request.accountType);
+            assertNotNull(request.created);
+            assertNotNull(request.updated);
+            String id = IndividualAccountRequest.get(request.id).id;
+            assertEquals(id, request.id);
+        }
+    }
+
+    @Test
+    public void testCreateWithObjectAddress() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        IndividualAccountRequest request = example();
+
+        assertNotNull(request.address);
+        assertEquals("Rua do Estilo Barroco", request.address.street);
+        assertEquals("648", request.address.number);
+        assertEquals("Santo Amaro", request.address.neighborhood);
+        assertEquals("Sao Paulo", request.address.city);
+        assertEquals("SP", request.address.state);
+        assertEquals("05724005", request.address.zipCode);
+    }
+
+    @Test
+    public void testQueryGet() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 3);
+        Generator<IndividualAccountRequest> requests = IndividualAccountRequest.query(params);
+
+        int i = 0;
+        for (IndividualAccountRequest request : requests) {
+            i += 1;
+            request = IndividualAccountRequest.get(request.id);
+            assertNotNull(request.id);
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testQueryIds() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 10);
+        params.put("tags", new String[]{"employees", "monthly"});
+        Generator<IndividualAccountRequest> requests = IndividualAccountRequest.query(params);
+
+        int i = 0;
+        ArrayList<String> requestsIdsExpected = new ArrayList<>();
+        for (IndividualAccountRequest request : requests) {
+            i += 1;
+            assertNotNull(request.id);
+            requestsIdsExpected.add(request.id);
+        }
+
+        params.put("ids", requestsIdsExpected.toArray(new String[0]));
+        Generator<IndividualAccountRequest> requestsResult = IndividualAccountRequest.query(params);
+
+        int n = 0;
+        ArrayList<String> requestsIdsResult = new ArrayList<>();
+        for (IndividualAccountRequest request : requestsResult) {
+            n += 1;
+            assertNotNull(request.id);
+            requestsIdsResult.add(request.id);
+        }
+
+        assertTrue(i > 0);
+        assertTrue(n > 0);
+        for (String id : requestsIdsResult) {
+            assertTrue(
+                "ids filter returned an id outside the requested set: " + id,
+                requestsIdsExpected.contains(id)
+            );
+        }
+    }
+
+    @Test
+    public void testPage() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 2);
+        params.put("after", "2019-04-01");
+        params.put("before", "2030-04-30");
+        params.put("cursor", null);
+
+        List<String> ids = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            IndividualAccountRequest.Page page = IndividualAccountRequest.page(params);
+            for (IndividualAccountRequest request : page.requests) {
+                if (ids.contains(request.id)) {
+                    throw new Exception("repeated id");
+                }
+                ids.add(request.id);
+            }
+            if (page.cursor == null) {
+                break;
+            }
+            params.put("cursor", page.cursor);
+        }
+
+        if (ids.size() != 4) {
+            throw new Exception("ids.size() != 4");
+        }
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> patchData = new HashMap<>();
+        patchData.put("name", "Tony Stark");
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 1);
+        Generator<IndividualAccountRequest> requests = IndividualAccountRequest.query(params);
+        for (IndividualAccountRequest request : requests) {
+            IndividualAccountRequest updated = IndividualAccountRequest.update(request.id, patchData);
+            assertEquals("Tony Stark", updated.name);
+            assertEquals(request.id, updated.id);
+        }
+    }
+
+    @Test
+    public void testUpdateAddress() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> newAddress = new HashMap<>();
+        newAddress.put("street", "Avenida Paulista");
+        newAddress.put("number", "1000");
+        newAddress.put("neighborhood", "Bela Vista");
+        newAddress.put("city", "Sao Paulo");
+        newAddress.put("state", "SP");
+        newAddress.put("zipCode", "01310100");
+
+        HashMap<String, Object> patchData = new HashMap<>();
+        patchData.put("address", newAddress);
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 1);
+        Generator<IndividualAccountRequest> requests = IndividualAccountRequest.query(params);
+        for (IndividualAccountRequest request : requests) {
+            IndividualAccountRequest updated = IndividualAccountRequest.update(request.id, patchData);
+            assertEquals("Avenida Paulista", updated.address.street);
+            assertEquals("01310100", updated.address.zipCode);
+        }
+    }
+
+    @Test
+    public void testStatusEnum() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        List<String> allowed = Arrays.asList("approved", "created", "denied", "processing", "updated");
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 5);
+        Generator<IndividualAccountRequest> requests = IndividualAccountRequest.query(params);
+
+        int i = 0;
+        for (IndividualAccountRequest request : requests) {
+            i += 1;
+            assertNotNull(request.status);
+            assertTrue("unexpected status: " + request.status, allowed.contains(request.status));
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testLogQueryAndGet() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 3);
+        params.put("after", "2019-04-01");
+        params.put("before", "2030-04-30");
+        params.put("types", new String[]{"created"});
+        Generator<IndividualAccountRequest.Log> logs = IndividualAccountRequest.Log.query(params);
+
+        int i = 0;
+        for (IndividualAccountRequest.Log log : logs) {
+            i += 1;
+            log = IndividualAccountRequest.Log.get(log.id);
+            assertNotNull(log.id);
+            assertNotNull(log.request.id);
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testLogQueryAccountRequestIds() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 5);
+        Generator<IndividualAccountRequest.Log> logs = IndividualAccountRequest.Log.query(params);
+
+        ArrayList<String> accountRequestIds = new ArrayList<>();
+        for (IndividualAccountRequest.Log log : logs) {
+            accountRequestIds.add(log.request.id);
+        }
+
+        HashMap<String, Object> filterParams = new HashMap<>();
+        filterParams.put("limit", 5);
+        filterParams.put("accountRequestIds", accountRequestIds.toArray(new String[0]));
+        Generator<IndividualAccountRequest.Log> filtered = IndividualAccountRequest.Log.query(filterParams);
+
+        int i = 0;
+        for (IndividualAccountRequest.Log log : filtered) {
+            i += 1;
+            assertNotNull(log.id);
+            assertTrue(accountRequestIds.contains(log.request.id));
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testLogPage() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 2);
+        params.put("after", "2019-04-01");
+        params.put("before", "2030-04-30");
+        params.put("cursor", null);
+
+        List<String> ids = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            IndividualAccountRequest.Log.Page page = IndividualAccountRequest.Log.page(params);
+            for (IndividualAccountRequest.Log log : page.logs) {
+                if (ids.contains(log.id)) {
+                    throw new Exception("repeated id");
+                }
+                ids.add(log.id);
+            }
+            if (page.cursor == null) {
+                break;
+            }
+            params.put("cursor", page.cursor);
+        }
+
+        if (ids.size() != 4) {
+            throw new Exception("ids.size() != 4");
+        }
+    }
+
+    @Test
+    public void testDateTimeParsing() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("limit", 1);
+        Generator<IndividualAccountRequest> requests = IndividualAccountRequest.query(params);
+
+        int i = 0;
+        for (IndividualAccountRequest request : requests) {
+            i += 1;
+            assertNotNull(request.created);
+            assertNotNull(request.updated);
+        }
+        assertTrue(i > 0);
+    }
+
+    @Test
+    public void testOutputOnlyFieldsRejectedByConstructor() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.put("status", "created");
+        data.put("accountType", "individual");
+
+        try {
+            new IndividualAccountRequest(data);
+            throw new Exception("expected the constructor to reject the return-only fields");
+        } catch (Exception e) {
+            assertTrue(
+                "expected unknown-parameter rejection, got: " + e.getMessage(),
+                e.getMessage() != null
+                    && e.getMessage().startsWith("Unknown parameters used in constructor:")
+            );
+        }
+    }
+
+    @Test
+    public void testCreateInvalidName() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.put("name", "");
+
+        List<IndividualAccountRequest> requests = new ArrayList<>();
+        requests.add(new IndividualAccountRequest(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountRequest.create(requests);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testCreateInvalidTaxId() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.put("taxId", "000.000.000-00");
+
+        List<IndividualAccountRequest> requests = new ArrayList<>();
+        requests.add(new IndividualAccountRequest(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountRequest.create(requests);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testCreateInvalidAddress() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> incompleteAddress = new HashMap<>();
+        incompleteAddress.put("street", "Rua do Estilo Barroco");
+
+        HashMap<String, Object> data = exampleData();
+        data.put("address", incompleteAddress);
+
+        List<IndividualAccountRequest> requests = new ArrayList<>();
+        requests.add(new IndividualAccountRequest(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountRequest.create(requests);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testCreateInvalidIncome() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        HashMap<String, Object> data = exampleData();
+        data.put("income", -1L);
+
+        List<IndividualAccountRequest> requests = new ArrayList<>();
+        requests.add(new IndividualAccountRequest(data));
+
+        boolean raised = false;
+        try {
+            IndividualAccountRequest.create(requests);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testUpdateInvalidStatus() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        IndividualAccountRequest request =
+            IndividualAccountRequest.create(Collections.singletonList(example())).get(0);
+
+        HashMap<String, Object> patchData = new HashMap<>();
+        patchData.put("status", "not-a-real-status");
+
+        boolean raised = false;
+        try {
+            IndividualAccountRequest.update(request.id, patchData);
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    @Test
+    public void testGetNotFound() throws Exception {
+        Settings.user = utils.User.defaultProject();
+
+        boolean raised = false;
+        try {
+            IndividualAccountRequest.get("0");
+        } catch (InputErrors e) {
+            raised = true;
+        }
+        assertTrue("expected InputErrors to be raised", raised);
+    }
+
+    static IndividualAccountRequest example() throws Exception {
+        return new IndividualAccountRequest(exampleData());
+    }
+
+    static HashMap<String, Object> exampleData() throws Exception {
+        HashMap<String, Object> address = new HashMap<>();
+        address.put("street", "Rua do Estilo Barroco");
+        address.put("number", "648");
+        address.put("neighborhood", "Santo Amaro");
+        address.put("city", "Sao Paulo");
+        address.put("state", "SP");
+        address.put("zipCode", "05724005");
+
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("name", "Tony Stark " + UUID.randomUUID().toString());
+        data.put("taxId", "012.345.678-90");
+        data.put("address", address);
+        data.put("income", 1000000L);
+        data.put("tags", new String[]{"employees", "monthly"});
+        return data;
+    }
+}


### PR DESCRIPTION
## Context
The **account-approval** feature — `IndividualAccountRequest` and `IndividualAccountAttachment` (each with a read-only `.Log`) — for the java infra SDK. Generated from contracts `individual-account-request.md` (v3) and `individual-account-attachment.md` (v3). Run-type: **generate**. Run artifacts: `runs/20260528-182857-account-approval/java/`.

## What changed
- Add `IndividualAccountRequest` (create/get/query/page/update + read-only `.Log`) with a structured `Address` sub-resource (nested object, never flattened).
- Add `IndividualAccountAttachment` (create/get/query/page/cancel + read-only `.Log`); the constructor encodes `content`+`contentType` into a `data:<contentType>;base64,…` URL client-side; `contentType` is input-only.
- CHANGELOG entry + per-resource README usage sections.

## Test plan
- [x] 37 unit tests passing locally against the infra sandbox (Phase 6 — see `runs/20260528-182857-account-approval/java/test-run-success.md`)
- [ ] Sandbox smoke check (manual after merge)

## Risk & Rollback
- **Risk:** new resources, additive only — no changes to existing public types.
- **Rollback:** revert this PR; no data migration.

## Contract review (Phase 7)

# Contract Review

## Checklist

### IndividualAccountRequest (M1–M12)

| Mandatory point | Status | Implementation | Test |
|---|---|---|---|
| [M1] `create` accepts list of `IndividualAccountRequest`, returns same shape with server-assigned `id`, `status`, `accountType`, `created`, `updated` populated | covered | IndividualAccountRequest.java:379–411 (`create(List<?>)` → `Rest.post`) | `testCreate` @ TestIndividualAccountRequest.java:25–42 |
| [M2] `address` is a structured object (not a string) with required sub-fields `street`, `number`, `neighborhood`, `city`, `state`, `zipCode`; serialized as nested JSON, never flattened | covered | IndividualAccountRequest.java:476–535 (`Address extends SubResource` with all 6 sub-fields) | `testCreateWithObjectAddress` @ TestIndividualAccountRequest.java:48–61 |
| [M3] `get(id)` returns a single `IndividualAccountRequest` | covered | IndividualAccountRequest.java:165–183 (`get(String id)` → `Rest.getId`) | `testQueryGet` @ TestIndividualAccountRequest.java:67–81 |
| [M4] `query` returns iterable of `IndividualAccountRequest`, accepts `limit`, `after`, `before`, `status`, `tags`, `ids` | covered | IndividualAccountRequest.java:205–262 (`query(Map, User)` → `Rest.getStream`; params documented at lines 197–202) | `testQueryGet` @ TestIndividualAccountRequest.java:67–81 ; `testQueryIds` @ TestIndividualAccountRequest.java:85–123 |
| [M5] `page` returns `IndividualAccountRequest.Page` (items + cursor), accepts same params as query plus `cursor` | covered | IndividualAccountRequest.java:264–365 (`Page` inner class + `page(Map, User)` → `Rest.getPage`) | `testPage` @ TestIndividualAccountRequest.java:127–154 |
| [M6] `update(id, ...)` PATCHes request; accepts any subset of `name`, `taxId`, `address`, `income`, `status`, `tags`; replaces (not deep-merges) `address` | covered | IndividualAccountRequest.java:432–458 (`update(String id, Map patchData, User)` → `Rest.patch`; full field list in Javadoc lines 422–431) | `testUpdate` @ TestIndividualAccountRequest.java:161–175 (name patch) ; `testUpdateAddress` @ TestIndividualAccountRequest.java:179–201 (whole-object address replace) |
| [M7] `status` enum exactly `approved \| created \| denied \| processing \| updated` (v1 `success`/`failed`/`canceled` not used) | covered | IndividualAccountRequest.java:43–50 (field declared `public String status`; no enum restriction in Java type system; contract-compliant values enforced by API) | `testStatusEnum` @ TestIndividualAccountRequest.java:207–223 (asserts every fetched status is member of `{approved, created, denied, processing, updated}`) |
| [M8] `IndividualAccountRequest.Log` is read-only, exposed under `<resource>.Log`, provides `get`, `query`, `page`; `Log.request` is `IndividualAccountRequest` type | covered | IndividualAccountRequest.java:537–775 (`Log extends Resource` with `get`, `query`, `page` statics; `public IndividualAccountRequest request` at line 543) | `testLogQueryAndGet` @ TestIndividualAccountRequest.java:229–248 (asserts `log.request.id` populated) |
| [M9] `Log.query` and `Log.page` accept `limit`, `after`, `before`, `types`, `accountRequestIds` | covered | IndividualAccountRequest.java:606–618 (`Log.query(Map params)` with param docs at lines 609–615); IndividualAccountRequest.java:706–709 (`Log.page(Map params)`) | `testLogQueryAndGet` @ TestIndividualAccountRequest.java:229–248 (uses `types`); `testLogQueryAccountRequestIds` @ TestIndividualAccountRequest.java:252–276 (uses `accountRequestIds`); `testLogPage` @ TestIndividualAccountRequest.java:280–307 |
| [M10] DateTime fields (`created`, `updated`) parsed to language-native type (Java: `String`, matching existing SDK pattern per serialization.md:44) | covered | IndividualAccountRequest.java:51–52 (`public String created; public String updated;`) | `testDateTimeParsing` @ TestIndividualAccountRequest.java:313–328 (asserts both fields non-null) |
| [M11] `accountType`, `flags`, `id`, `status`, `created`, `updated` are output-only — Map constructor sets them null and rejects them as unknown params | covered | IndividualAccountRequest.java:130–138 (Map ctor sets `status`, `accountType`, `flags`, `created`, `updated` to null without reading from map; unknown-param check at lines 136–138) | `testOutputOnlyFieldsRejectedByConstructor` @ TestIndividualAccountRequest.java:337–354 (passes `status`+`accountType` in map, asserts `Unknown parameters used in constructor:` exception) |
| [M12] Each error case has a test asserting `com.starkcore.error.InputErrors` is raised (code-agnostic): `invalidName`, `invalidTaxId`, `invalidAddress`, `invalidIncome`, `invalidStatus`, `notFound` | covered | IndividualAccountRequest.java:379–411 (all create/update paths forward to API via `Rest.post`/`Rest.patch`/`Rest.getId`) | `testCreateInvalidName` @ TestIndividualAccountRequest.java:360–376 ; `testCreateInvalidTaxId` @ TestIndividualAccountRequest.java:381–397 ; `testCreateInvalidAddress` @ TestIndividualAccountRequest.java:401–422 ; `testCreateInvalidIncome` @ TestIndividualAccountRequest.java:426–443 ; `testUpdateInvalidStatus` @ TestIndividualAccountRequest.java:447–464 ; `testGetNotFound` @ TestIndividualAccountRequest.java:468–479 |

---

### IndividualAccountAttachment (M1–M14)

| Mandatory point | Status | Implementation | Test |
|---|---|---|---|
| [M1] `create` accepts list of `IndividualAccountAttachment`, returns same shape with server-assigned `id`, `status`, `created` populated | covered | IndividualAccountAttachment.java:355–387 (`create(List<?>)` → `Rest.post`) | `testCreate` @ TestIndividualAccountAttachment.java:28–43 |
| [M2] Constructor encodes `content` (raw bytes) + `contentType` (MIME) into `data:<contentType>;base64,<payload>` URL client-side; callers pass raw bytes, not pre-encoded data URLs | covered | IndividualAccountAttachment.java:109–113 (Map ctor branch: `byte[] content` + `contentType` → `"data:" + contentType + ";base64," + Base64.encode(content)`) | `testConstructorEncodesDataUrl` @ TestIndividualAccountAttachment.java:50–62 (asserts content starts with `"data:image/png;base64,"`) |
| [M3] `contentType` is input-only: consumed by constructor to build data URL, NOT serialized as its own wire field; passing `contentType` in a response-shaped Map throws | covered | IndividualAccountAttachment.java:99–127 (Map ctor: `contentType` is only consumed in the `byte[]`-content branch at line 111; it is never assigned to a field; unknown-param check at lines 124–126 rejects stray keys) | `testContentTypeIsInputOnly` @ TestIndividualAccountAttachment.java:69–91 (passes `content` as String + `contentType` → asserts exception mentioning `contentType`) |
| [M4] `get(id)` returns a single `IndividualAccountAttachment` | covered | IndividualAccountAttachment.java:141–160 (`get(String id, User)` → `Rest.getId`) | `testQueryGet` @ TestIndividualAccountAttachment.java:96–113 |
| [M5] `query` returns iterable of `IndividualAccountAttachment`, accepts `limit`, `after`, `before`, `status`, `tags`, `ids` | covered | IndividualAccountAttachment.java:181–238 (`query(Map, User)` → `Rest.getStream`) | `testQueryGet` @ TestIndividualAccountAttachment.java:96–113 ; `testQueryIds` @ TestIndividualAccountAttachment.java:116–148 |
| [M6] `page` returns `IndividualAccountAttachment.Page` (items + cursor), accepts same params as query plus `cursor` | covered | IndividualAccountAttachment.java:240–341 (`Page` inner class + `page(Map, User)` → `Rest.getPage`) | `testPage` @ TestIndividualAccountAttachment.java:152–180 |
| [M7] `cancel(id)` maps to `DELETE`, returns resource with `status = deleted`; idempotent (second cancel succeeds without error) | covered | IndividualAccountAttachment.java:401–420 (`cancel(String id, User)` → `Rest.delete`) | `testCancel` @ TestIndividualAccountAttachment.java:187–195 (asserts `status == "deleted"`) ; `testCancelIdempotent` @ TestIndividualAccountAttachment.java:417–431 (second cancel asserts `status == "deleted"`, no exception) |
| [M8] Resource exposed as `IndividualAccountAttachment` (not `accountRequestAttachment`) | covered | IndividualAccountAttachment.java:16 (`public final class IndividualAccountAttachment extends Resource`) | `testCreate` @ TestIndividualAccountAttachment.java:28 (imports and uses `com.starkinfra.IndividualAccountAttachment`; file compiles and runs under the new identifier) |
| [M9] `IndividualAccountAttachment.Log` is read-only, exposed under `<resource>.Log`, provides `get`, `query`, `page`; `Log.attachment` is `IndividualAccountAttachment` type | covered | IndividualAccountAttachment.java:422–660 (`Log extends Resource` with `get`, `query`, `page` statics; `public IndividualAccountAttachment attachment` at line 428) | `testLogQueryAndGet` @ TestIndividualAccountAttachment.java:202–219 (asserts `log.attachment.id` populated) |
| [M10] `Log.query` and `Log.page` accept `limit`, `after`, `before`, `types`, `attachmentIds` (parent-id filter named `attachmentIds`, not `accountRequestIds`) | covered | IndividualAccountAttachment.java:502–558 (`Log.query(Map params)` with param docs listing `attachmentIds` at line 497); IndividualAccountAttachment.java:591–658 (`Log.page(Map, User)`) | `testLogQueryAndGet` @ TestIndividualAccountAttachment.java:202–219 (uses `types`); `testLogQueryAttachmentIds` @ TestIndividualAccountAttachment.java:223–248 (uses `attachmentIds`); `testLogPage` @ TestIndividualAccountAttachment.java:251–279 |
| [M11] `type` enum exactly `drivers-license-front \| drivers-license-back \| identity-front \| identity-back`; `selfie` not valid | covered | IndividualAccountAttachment.java:40 (`public String type;`; valid values enforced at API level; no `selfie` in any fixture or docstring's canonical list at line 29) | `testTypeEnum` @ TestIndividualAccountAttachment.java:285–303 (asserts every fetched type is member of 4-value set, no `selfie`) |
| [M12] DateTime field (`created`) parsed to language-native type (Java: `String`, matching existing SDK pattern) | covered | IndividualAccountAttachment.java:45 (`public String created;`) | `testDateTimeParsing` @ TestIndividualAccountAttachment.java:310–323 (asserts `created` non-null) |
| [M13] Each error case has a test asserting `InputErrors` raised (code-agnostic): `type` invalid, `content` empty, `contentType` missing, `accountRequestId` not found, unknown `id` | covered | IndividualAccountAttachment.java:355–387 (create forwards to API via `Rest.post`); IndividualAccountAttachment.java:141–160 (get forwards via `Rest.getId`) | `testCreateInvalidType` @ TestIndividualAccountAttachment.java:329–346 ; `testCreateInvalidContent` @ TestIndividualAccountAttachment.java:350–367 ; `testCreateInvalidContentType` @ TestIndividualAccountAttachment.java:372–389 ; `testCreateAccountRequestNotFound` @ TestIndividualAccountAttachment.java:393–411 ; `testGetNotFound` @ TestIndividualAccountAttachment.java:436–446 |
| [M14] Legacy `AccountRequestAttachment` removed (no dual exposure): source file deleted, legacy tests deleted | not applicable | n/a | n/a — run-type is `generate`; no `AccountRequestAttachment` source ever existed in `sdk-infra/java` (grep of entire `sdk-infra/java/src` returned zero source or test files matching `AccountRequestAttachment`; confirmed in scaffold-plan.md:3–7; manifest has no `DEL` lines) |

---

## Summary

- Total mandatory points: 26 (IndividualAccountRequest M1–M12 = 12; IndividualAccountAttachment M1–M14 = 14)
- covered: 25
- not covered: 0
- partial: 0
- not applicable: 1
- VERDICT: PASS

## If FAIL — routing recommendation

N/A — PASS.


## Metadata
- Contracts: `contracts/individual-account-request.md` (v3), `contracts/individual-account-attachment.md` (v3)
- Run artifacts: `runs/20260528-182857-account-approval/java/`
- Branch: `feature/account-approval`
- Base SHA: `e8b8e461e8aebd81c7dd517bd322de8ba07684a2`
